### PR TITLE
Add basic frontend

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,76 @@
+const loginTab = document.getElementById('login-tab');
+const registerTab = document.getElementById('register-tab');
+const loginForm = document.getElementById('login-form');
+const registerForm = document.getElementById('register-form');
+const message = document.getElementById('message');
+
+// Toggle forms
+loginTab.addEventListener('click', () => {
+    loginTab.classList.add('active');
+    registerTab.classList.remove('active');
+    loginForm.classList.add('active');
+    registerForm.classList.remove('active');
+    message.textContent = '';
+});
+
+registerTab.addEventListener('click', () => {
+    registerTab.classList.add('active');
+    loginTab.classList.remove('active');
+    registerForm.classList.add('active');
+    loginForm.classList.remove('active');
+    message.textContent = '';
+});
+
+const apiUrl = 'http://localhost:5000/api/users';
+
+loginForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const email = document.getElementById('login-email').value;
+    const password = document.getElementById('login-password').value;
+
+    try {
+        const res = await fetch(`${apiUrl}/login`, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            credentials: 'include',
+            body: JSON.stringify({email, password})
+        });
+        const data = await res.json();
+        if (res.ok) {
+            message.style.color = 'green';
+            message.textContent = `Welcome ${data.name}`;
+        } else {
+            throw new Error(data.message || 'Login failed');
+        }
+    } catch (err) {
+        message.style.color = 'red';
+        message.textContent = err.message;
+    }
+});
+
+registerForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const name = document.getElementById('register-name').value;
+    const email = document.getElementById('register-email').value;
+    const password = document.getElementById('register-password').value;
+
+    try {
+        const res = await fetch(`${apiUrl}/register`, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            credentials: 'include',
+            body: JSON.stringify({name, email, password})
+        });
+        const data = await res.json();
+        if (res.ok) {
+            message.style.color = 'green';
+            message.textContent = 'Registration successful. You can log in now.';
+            registerForm.reset();
+        } else {
+            throw new Error(data.message || 'Registration failed');
+        }
+    } catch (err) {
+        message.style.color = 'red';
+        message.textContent = err.message;
+    }
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Shopllica Auth</title>
+    <link rel="stylesheet" href="main.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Shopllica</h1>
+        <div class="tabs">
+            <button id="login-tab" class="active">Login</button>
+            <button id="register-tab">Register</button>
+        </div>
+        <form id="login-form" class="form active">
+            <input type="email" id="login-email" placeholder="Email" required>
+            <input type="password" id="login-password" placeholder="Password" required>
+            <button type="submit">Login</button>
+        </form>
+        <form id="register-form" class="form">
+            <input type="text" id="register-name" placeholder="Name" required>
+            <input type="email" id="register-email" placeholder="Email" required>
+            <input type="password" id="register-password" placeholder="Password" required>
+            <button type="submit">Register</button>
+        </form>
+        <p id="message"></p>
+    </div>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/frontend/main.css
+++ b/frontend/main.css
@@ -1,0 +1,74 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f2f2f2;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    margin: 0;
+}
+
+.container {
+    background: #fff;
+    padding: 2rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    width: 300px;
+}
+
+h1 {
+    text-align: center;
+    color: #008080;
+    margin-top: 0;
+}
+
+.tabs {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+}
+
+.tabs button {
+    flex: 1;
+    padding: 0.5rem;
+    border: none;
+    cursor: pointer;
+    background: #e0e0e0;
+    color: #333;
+}
+
+.tabs button.active {
+    background: #008080;
+    color: #fff;
+}
+
+.form {
+    display: none;
+    flex-direction: column;
+}
+
+.form.active {
+    display: flex;
+}
+
+.form input {
+    margin-bottom: 0.5rem;
+    padding: 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+.form button {
+    padding: 0.5rem;
+    background: #008080;
+    border: none;
+    color: #fff;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+#message {
+    text-align: center;
+    color: red;
+    margin-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- provide a simple login/registration page for the backend
- apply teal themed styling
- add JS fetch logic for calling `/api/users` endpoints

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68416ac1c0f88322ad8011a9df04e1b2